### PR TITLE
Implement missing action representations

### DIFF
--- a/src/main/java/com/untamedears/jukealert/listener/LoggableActionListener.java
+++ b/src/main/java/com/untamedears/jukealert/listener/LoggableActionListener.java
@@ -32,6 +32,9 @@ import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.vehicle.VehicleDestroyEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
+import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.InventoryHolder;
@@ -116,6 +119,42 @@ public class LoggableActionListener implements Listener {
 		String victimName = getEntityName(victim);
 		handlePlayerAction(killer, s -> new KillLivingEntityAction(System.currentTimeMillis(), s, killer.getUniqueId(),
 				victim.getLocation(), victimName));
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onDestroyVehicle(VehicleDestroyEvent event) {
+		if (event.getAttacker().getType() != EntityType.PLAYER) {
+			return;
+		}
+
+		Player player = (Player) event.getAttacker();
+
+		handlePlayerAction(player, s -> new DestroyVehicleAction(System.currentTimeMillis(), s,
+				player.getUniqueId(), event.getVehicle().getLocation(), getEntityName(event.getVehicle())));
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onEnterVehicle(VehicleEnterEvent event) {
+		if (event.getEntered().getType() != EntityType.PLAYER) {
+			return;
+		}
+
+		Player player = (Player) event.getEntered();
+
+		handlePlayerAction(player, s -> new EnterVehicleAction(System.currentTimeMillis(), s,
+				player.getUniqueId(), event.getVehicle().getLocation(), getEntityName(event.getVehicle())));
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onExitVehicle(VehicleExitEvent event) {
+		if (event.getExited().getType() != EntityType.PLAYER) {
+			return;
+		}
+
+		Player player = (Player) event.getExited();
+
+		handlePlayerAction(player, s -> new ExitVehicleAction(System.currentTimeMillis(), s,
+				player.getUniqueId(), event.getVehicle().getLocation(), getEntityName(event.getVehicle())));
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/src/main/java/com/untamedears/jukealert/listener/LoggableActionListener.java
+++ b/src/main/java/com/untamedears/jukealert/listener/LoggableActionListener.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.Function;
 
+import com.untamedears.jukealert.model.actions.impl.*;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -41,19 +42,6 @@ import com.untamedears.jukealert.SnitchManager;
 import com.untamedears.jukealert.external.VanishNoPacket;
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.SnitchAction;
-import com.untamedears.jukealert.model.actions.impl.BlockBreakAction;
-import com.untamedears.jukealert.model.actions.impl.BlockPlaceAction;
-import com.untamedears.jukealert.model.actions.impl.EmptyBucketAction;
-import com.untamedears.jukealert.model.actions.impl.EnterFieldAction;
-import com.untamedears.jukealert.model.actions.impl.FillBucketAction;
-import com.untamedears.jukealert.model.actions.impl.IgniteBlockAction;
-import com.untamedears.jukealert.model.actions.impl.KillLivingEntityAction;
-import com.untamedears.jukealert.model.actions.impl.KillPlayerAction;
-import com.untamedears.jukealert.model.actions.impl.LeaveFieldAction;
-import com.untamedears.jukealert.model.actions.impl.LoginAction;
-import com.untamedears.jukealert.model.actions.impl.LogoutAction;
-import com.untamedears.jukealert.model.actions.impl.MountEntityAction;
-import com.untamedears.jukealert.model.actions.impl.OpenContainerAction;
 import com.untamedears.jukealert.util.JukeAlertPermissionHandler;
 
 public class LoggableActionListener implements Listener {
@@ -160,7 +148,7 @@ public class LoggableActionListener implements Listener {
 		}
 		Player player = (Player) event.getEntity();
 		String mountName = getEntityName(event.getDismounted());
-		handlePlayerAction(player, s -> new MountEntityAction(System.currentTimeMillis(), s, player.getUniqueId(),
+		handlePlayerAction(player, s -> new DismountEntityAction(System.currentTimeMillis(), s, player.getUniqueId(),
 				event.getDismounted().getLocation(), mountName));
 	}
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockBreakAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockBreakAction.java
@@ -11,6 +11,8 @@ import com.untamedears.jukealert.model.actions.abstr.LoggableBlockAction;
 import com.untamedears.jukealert.util.JAUtility;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 
@@ -33,8 +35,12 @@ public class BlockBreakAction extends LoggableBlockAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(getMaterial());
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Break");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockBreakAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockBreakAction.java
@@ -13,6 +13,7 @@ import com.untamedears.jukealert.util.JAUtility;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
@@ -11,6 +11,8 @@ import com.untamedears.jukealert.model.actions.abstr.LoggableBlockAction;
 import com.untamedears.jukealert.util.JAUtility;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 
@@ -33,8 +35,12 @@ public class BlockPlaceAction extends LoggableBlockAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(getMaterial());
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Place");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
@@ -13,6 +13,7 @@ import com.untamedears.jukealert.util.JAUtility;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/BlockPlaceAction.java
@@ -13,6 +13,7 @@ import com.untamedears.jukealert.util.JAUtility;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.api.ItemAPI;
 import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
@@ -36,11 +37,17 @@ public class BlockPlaceAction extends LoggableBlockAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		ItemStack is = new ItemStack(getMaterial());
-		ItemMeta itemMeta = is.getItemMeta();
-		itemMeta.setDisplayName(ChatColor.GOLD + "Place");
-		is.setItemMeta(itemMeta);
-		super.enrichGUIItem(is);
+		ItemStack is;
+		try {
+			is = new ItemStack(getMaterial());
+			ItemAPI.setDisplayName(is,ChatColor.GOLD + "Place");
+			super.enrichGUIItem(is);
+		} catch (Exception e) {
+			is = new ItemStack(Material.STONE);
+			ItemAPI.setDisplayName(is, ChatColor.GOLD + "Place");
+			ItemAPI.addLore(is, String.format("%sMaterial: %s%s", ChatColor.GOLD, ChatColor.AQUA, getMaterial().toString()));
+			super.enrichGUIItem(is);
+		}
 		return new DecorationStack(is);
 	}
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
@@ -28,7 +28,7 @@ public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 	public IClickable getGUIRepresentation() {
 		ItemStack is = new ItemStack(getVehicle());
 		ItemMeta itemMeta = is.getItemMeta();
-		itemMeta.setDisplayName(ChatColor.GOLD + "Break");
+		itemMeta.setDisplayName(ChatColor.GOLD + "Broke Vehicle");
 		is.setItemMeta(itemMeta);
 		super.enrichGUIItem(is);
 		return new DecorationStack(is);

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
@@ -36,7 +36,7 @@ public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Break  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%Broke Vehicle  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
@@ -13,6 +13,7 @@ import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
@@ -2,6 +2,8 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 
@@ -9,7 +11,10 @@ import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 	
@@ -21,14 +26,19 @@ public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(getVehicle());
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Break");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Break  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 	
 	/**

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DestroyVehicleAction.java
@@ -37,7 +37,7 @@ public class DestroyVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Broke Vehicle  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sBroke Vehicle  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
@@ -13,6 +13,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.api.ItemAPI;
 import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
@@ -28,9 +29,7 @@ public class DismountEntityAction extends LoggablePlayerVictimAction {
 	@Override
 	public IClickable getGUIRepresentation() {
 		ItemStack is = new ItemStack(Material.SADDLE);
-		ItemMeta itemMeta = is.getItemMeta();
-		itemMeta.setDisplayName(ChatColor.GOLD + "Dismounted");
-		is.setItemMeta(itemMeta);
+		ItemAPI.setDisplayName(is,String.format("%sDismounted %s%s", ChatColor.GOLD, ChatColor.AQUA, getVictim()));
 		super.enrichGUIItem(is);
 		return new DecorationStack(is);
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
@@ -2,13 +2,20 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class DismountEntityAction extends LoggablePlayerVictimAction {
 	
@@ -20,17 +27,24 @@ public class DismountEntityAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		return null;
+		ItemStack is = new ItemStack(Material.SADDLE);
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Dismounted");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return null;
+		return new TextComponent(String.format("%Dismounted  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictim(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 
 	@Override
 	public String getIdentifier() {
-		return null;
+		return ID;
 	}
 
 }

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/DismountEntityAction.java
@@ -37,7 +37,7 @@ public class DismountEntityAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Dismounted  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sDismounted  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictim(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
@@ -37,7 +37,7 @@ public class EmptyBucketAction extends LoggableBlockAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Emptied Bucket  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sEmptied Bucket  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, material.toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
@@ -2,6 +2,8 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 
@@ -9,7 +11,10 @@ import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggableBlockAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class EmptyBucketAction extends LoggableBlockAction {
 	
@@ -21,14 +26,19 @@ public class EmptyBucketAction extends LoggableBlockAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(material);
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Emptied Bucket");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Emptied Bucket  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, material.toString(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/EmptyBucketAction.java
@@ -13,6 +13,7 @@ import com.untamedears.jukealert.model.actions.abstr.LoggableBlockAction;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
@@ -2,13 +2,19 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class EnterVehicleAction extends LoggablePlayerVictimAction {
 
@@ -20,14 +26,26 @@ public class EnterVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(getVehicle());
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Entered Vehicle");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Break  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
+	}
+
+	/**
+	 * @return Material of the entered vehicle
+	 */
+	public Material getVehicle() {
+		return Material.valueOf(victim);
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
@@ -13,6 +13,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
@@ -37,7 +37,7 @@ public class EnterVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Entered Vehicle  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sEntered Vehicle  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/EnterVehicleAction.java
@@ -36,7 +36,7 @@ public class EnterVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Break  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%Entered Vehicle  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
@@ -13,6 +13,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
@@ -2,13 +2,19 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class ExitVehicleAction extends LoggablePlayerVictimAction {
 
@@ -20,14 +26,26 @@ public class ExitVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(getVehicle());
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Exited Vehicle");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Break  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
+	}
+
+	/**
+	 * @return Material of the exited vehicle
+	 */
+	public Material getVehicle() {
+		return Material.valueOf(victim);
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/ExitVehicleAction.java
@@ -37,7 +37,7 @@ public class ExitVehicleAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Break  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sBreak  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, getVehicle().toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
@@ -2,6 +2,8 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 
@@ -9,7 +11,10 @@ import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggableBlockAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class FillBucketAction extends LoggableBlockAction {
 	
@@ -21,14 +26,19 @@ public class FillBucketAction extends LoggableBlockAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(material);
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Filled Bucket");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Filled Bucket  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, material.toString(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
@@ -13,6 +13,7 @@ import com.untamedears.jukealert.model.actions.abstr.LoggableBlockAction;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/FillBucketAction.java
@@ -37,7 +37,7 @@ public class FillBucketAction extends LoggableBlockAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Filled Bucket  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sFilled Bucket  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, material.toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
@@ -2,6 +2,8 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 
 import com.untamedears.jukealert.model.Snitch;
@@ -9,7 +11,11 @@ import com.untamedears.jukealert.model.actions.LoggedActionPersistence;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class IgniteBlockAction extends LoggablePlayerAction  {
 	
@@ -24,14 +30,19 @@ public class IgniteBlockAction extends LoggablePlayerAction  {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(Material.FLINT_AND_STEEL);
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Ignited");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Ignited  %s%s  %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 	
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
@@ -14,6 +14,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/IgniteBlockAction.java
@@ -41,7 +41,7 @@ public class IgniteBlockAction extends LoggablePlayerAction  {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Ignited  %s%s  %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sIgnited  %s%s  %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/KillLivingEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/KillLivingEntityAction.java
@@ -37,7 +37,7 @@ public class KillLivingEntityAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Killed Mob  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sKilled Mob  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictim(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/KillLivingEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/KillLivingEntityAction.java
@@ -2,32 +2,44 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class KillLivingEntityAction extends LoggablePlayerVictimAction {
 	
 	public static final String ID = "KILL_MOB";
 
 	public KillLivingEntityAction(long time, Snitch snitch, UUID player, Location location,String victimName) {
-		super(time, snitch, player, location,victimName);
+		super(time, snitch, player, location, victimName);
 	}
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(Material.DIAMOND_SWORD);
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Killed Mob");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Killed Mob  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictim(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
@@ -11,6 +11,7 @@ import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
@@ -38,6 +39,7 @@ public class KillPlayerAction extends LoggablePlayerVictimAction {
 		ItemStack is = new ItemStack(Material.DIAMOND_SWORD);
 		ItemMeta itemMeta = is.getItemMeta();
 		itemMeta.setDisplayName(ChatColor.GOLD + "Killed Player");
+		itemMeta.addEnchant(Enchantment.DAMAGE_ALL, 1, true);
 		is.setItemMeta(itemMeta);
 		super.enrichGUIItem(is);
 		return new DecorationStack(is);

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
@@ -2,12 +2,18 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
 
@@ -29,14 +35,19 @@ public class KillPlayerAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(Material.DIAMOND_SWORD);
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Killed Player");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Killed Player  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictimName(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 
 	@Override

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/KillPlayerAction.java
@@ -45,7 +45,7 @@ public class KillPlayerAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Killed Player  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sKilled Player  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictimName(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
@@ -13,6 +13,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.api.ItemAPI;
 import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
 import vg.civcraft.mc.namelayer.NameAPI;
@@ -28,9 +29,7 @@ public class MountEntityAction extends LoggablePlayerVictimAction {
 	@Override
 	public IClickable getGUIRepresentation() {
 		ItemStack is = new ItemStack(Material.SADDLE);
-		ItemMeta itemMeta = is.getItemMeta();
-		itemMeta.setDisplayName(ChatColor.GOLD + "Mounted");
-		is.setItemMeta(itemMeta);
+		ItemAPI.setDisplayName(is,String.format("%Mounted %s%s", ChatColor.GOLD, ChatColor.AQUA, getVictim()));
 		super.enrichGUIItem(is);
 		return new DecorationStack(is);
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
@@ -2,13 +2,20 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 
 import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggablePlayerVictimAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class MountEntityAction extends LoggablePlayerVictimAction {
 
@@ -20,17 +27,24 @@ public class MountEntityAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		return null;
+		ItemStack is = new ItemStack(Material.SADDLE);
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Mounted");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return null;
+		return new TextComponent(String.format("%Mounted  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictim(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 
 	@Override
 	public String getIdentifier() {
-		return null;
+		return ID;
 	}
 
 }

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/MountEntityAction.java
@@ -37,7 +37,7 @@ public class MountEntityAction extends LoggablePlayerVictimAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Mounted  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sMounted  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()),ChatColor.AQUA, getVictim(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/OpenContainerAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/OpenContainerAction.java
@@ -37,7 +37,7 @@ public class OpenContainerAction extends LoggableBlockAction {
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		return new TextComponent(String.format("%Opened  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+		return new TextComponent(String.format("%sOpened  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
 				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, material.toString(), ChatColor.YELLOW,
 				JAUtility.formatLocation(location, false)));
 	}

--- a/src/main/java/com/untamedears/jukealert/model/actions/impl/OpenContainerAction.java
+++ b/src/main/java/com/untamedears/jukealert/model/actions/impl/OpenContainerAction.java
@@ -2,6 +2,8 @@ package com.untamedears.jukealert.model.actions.impl;
 
 import java.util.UUID;
 
+import com.untamedears.jukealert.util.JAUtility;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 
@@ -9,7 +11,11 @@ import com.untamedears.jukealert.model.Snitch;
 import com.untamedears.jukealert.model.actions.abstr.LoggableBlockAction;
 
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import vg.civcraft.mc.civmodcore.inventorygui.DecorationStack;
 import vg.civcraft.mc.civmodcore.inventorygui.IClickable;
+import vg.civcraft.mc.namelayer.NameAPI;
 
 public class OpenContainerAction extends LoggableBlockAction {
 	
@@ -21,14 +27,19 @@ public class OpenContainerAction extends LoggableBlockAction {
 
 	@Override
 	public IClickable getGUIRepresentation() {
-		// TODO Auto-generated method stub
-		return null;
+		ItemStack is = new ItemStack(getMaterial());
+		ItemMeta itemMeta = is.getItemMeta();
+		itemMeta.setDisplayName(ChatColor.GOLD + "Opened");
+		is.setItemMeta(itemMeta);
+		super.enrichGUIItem(is);
+		return new DecorationStack(is);
 	}
 
 	@Override
 	public TextComponent getChatRepresentation(Location reference) {
-		// TODO Auto-generated method stub
-		return null;
+		return new TextComponent(String.format("%Opened  %s%s  %s%s %s%s", ChatColor.GOLD, ChatColor.GREEN,
+				NameAPI.getCurrentName(getPlayer()), ChatColor.AQUA, material.toString(), ChatColor.YELLOW,
+				JAUtility.formatLocation(location, false)));
 	}
 
 	@Override


### PR DESCRIPTION
Added all of the missing GUI/Chat representations.

Made DismountEntityAction be called in the relevant event.

These have had their missing events added:
- Destroy Vehicle
- Enter Vehicle
- Exit Vehicle

Not tested in-game.