### PR TITLE
Fixed /ctf not creating snitches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,21 +1,46 @@
+@Library('civ_pipeline_lib')_
+
 pipeline {
     agent any
     tools {
         maven 'Maven 3.6.3'
         jdk 'Java 8'
     }
+    environment {
+    	civ_dependent_plugins = ""
+    }
      stages {
         stage ('Build') {
             steps {
-                sh 'mvn -U clean install deploy -P civ-jenkins'
+                civ_build_plugin()
+            }
+        }
+        stage ('Archive binaries') {
+            steps {
+                civ_archive_artifacts()
+            }
+        }
+        stage ('Archive javadoc') {
+            steps {
+                civ_archive_javadoc()
+            }
+        }
+        stage ('Aggregate reports') {
+            steps {
+                civ_aggregate_reports()
             }
         }
     }
+
     post {
         always {
-            withCredentials([string(credentialsId: 'civclassic-discord-webhook', variable: 'DISCORD_WEBHOOK')]) {
-                discordSend description: "**Build:** [${currentBuild.id}](${env.BUILD_URL})\n**Status:** [${currentBuild.currentResult}](${env.BUILD_URL})\n", footer: 'Civclassic Jenkins', link: env.BUILD_URL, successful: currentBuild.resultIsBetterOrEqualTo('SUCCESS'), title: "${env.JOB_NAME} #${currentBuild.id}", webhookURL: DISCORD_WEBHOOK
-            }
+           civ_post_always()
+        }
+        success {
+           civ_post_success()
+        }
+        failure {
+           civ_post_failure()
         }
     }
 }

--- a/src/main/java/com/untamedears/jukealert/JukeAlert.java
+++ b/src/main/java/com/untamedears/jukealert/JukeAlert.java
@@ -74,12 +74,12 @@ public class JukeAlert extends ACivMod {
 		configManager = new JAConfigManager(this, snitchConfigManager);
 		saveDefaultConfig();
 		dao = new JukeAlertDAO(getLogger(), configManager.getDatabase(getConfig()));
-		loggedActionFactory = new LoggedActionFactory();
 		if (!dao.updateDatabase()) {
 			getLogger().severe("Errors setting up database, shutting down");
 			Bukkit.shutdown();
 			return;
 		}
+		loggedActionFactory = new LoggedActionFactory();
 		SingleBlockAPIView<Snitch> api = ChunkMetaAPI.registerSingleTrackingPlugin(this, dao);
 		if (api == null) {
 			getLogger().severe("Errors setting up chunk metadata API, shutting down");

--- a/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
+++ b/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
@@ -42,7 +42,7 @@ public class SnitchLifeCycleListener implements Listener {
 		this.pendingSnitches = new HashMap<>();
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockPlace(BlockPlaceEvent event) {
 		ItemStack inHand = event.getItemInHand();
 		SnitchFactoryType type = configManager.getConfig(inHand);

--- a/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
+++ b/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
@@ -42,7 +42,7 @@ public class SnitchLifeCycleListener implements Listener {
 		this.pendingSnitches = new HashMap<>();
 	}
 
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onBlockPlace(BlockPlaceEvent event) {
 		ItemStack inHand = event.getItemInHand();
 		SnitchFactoryType type = configManager.getConfig(inHand);

--- a/src/main/java/com/untamedears/jukealert/util/JAUtility.java
+++ b/src/main/java/com/untamedears/jukealert/util/JAUtility.java
@@ -26,6 +26,8 @@ public final class JAUtility {
 	private JAUtility() {
 
 	}
+	
+	private static double tanPiDiv = Math.sqrt(2.0) - 1.0;
 
 	public static Snitch findClosestSnitch(Location loc, PermissionType perm, UUID player) {
 		Snitch closestSnitch = null;
@@ -73,11 +75,14 @@ public final class JAUtility {
 	}
 
 	public static String genDirections(Snitch snitch, Player player) {
-		return String.format("%s[%sm %s%s%s]", ChatColor.GREEN, Math.round(player.getLocation().distance(snitch.getLocation())), ChatColor.RED, getCardinal(player.getLocation(), snitch.getLocation()), ChatColor.GREEN);
+		if (snitch.getLocation().getWorld().equals(player.getLocation().getWorld())) {
+			return String.format("%s[%sm %s%s%s]", ChatColor.GREEN, Math.round(player.getLocation().distance(snitch.getLocation())), ChatColor.RED, getCardinal(player.getLocation(), snitch.getLocation()), ChatColor.GREEN);
+		} else {
+			return ""; // Can't get directions to another world
+		}
 	}
 
 	public static String getCardinal(Location start, Location end) {
-		double tanPiDiv = Math.sqrt(2.0) - 1.0;
 		double dX = start.getBlockX() - end.getBlockX();
 		double dZ = start.getBlockZ() - end.getBlockZ();
 


### PR DESCRIPTION
Fix to #16

The `ReinforcementCreationEvent` handler was executed before the call to `BlockPlaceEvent`.
This meant that: `pendingSnitches.remove(block.getLocation())` in the RCE handler was returning null and prevented the snitch creation.