### PR TITLE
Fixed /ctf not creating snitches

### DIFF
--- a/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
+++ b/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
@@ -42,7 +42,7 @@ public class SnitchLifeCycleListener implements Listener {
 		this.pendingSnitches = new HashMap<>();
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onBlockPlace(BlockPlaceEvent event) {
 		ItemStack inHand = event.getItemInHand();
 		SnitchFactoryType type = configManager.getConfig(inHand);

--- a/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
+++ b/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
@@ -42,7 +42,7 @@ public class SnitchLifeCycleListener implements Listener {
 		this.pendingSnitches = new HashMap<>();
 	}
 
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onBlockPlace(BlockPlaceEvent event) {
 		ItemStack inHand = event.getItemInHand();
 		SnitchFactoryType type = configManager.getConfig(inHand);

--- a/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
+++ b/src/main/java/com/untamedears/jukealert/listener/SnitchLifeCycleListener.java
@@ -51,6 +51,19 @@ public class SnitchLifeCycleListener implements Listener {
 		}
 	}
 
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
+	public void onBlockPlaceCancelled(BlockPlaceEvent event) {
+		if (!event.isCancelled()) {
+			return;
+		}
+		ItemStack inHand = event.getItemInHand();
+		SnitchFactoryType type = configManager.getConfig(inHand);
+		if (type != null) {
+			Block block = event.getBlock();
+			pendingSnitches.remove(block.getLocation());
+		}
+	}
+
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent event) {
 		Block block = event.getBlock();


### PR DESCRIPTION
Note: Closed #17 and made a new commit because of git shenanigans on my part. I apologize for the trouble.

> Fix to #16

> The ReinforcementCreationEvent handler was executed before the call to BlockPlaceEvent.
> This meant that: pendingSnitches.remove(block.getLocation()) in the RCE handler was returning null and prevented the snitch creation.

I got busy IRL shortly the time I made the first PR and I haven't really looked into it after that. Since it seems to still an issue, I'm taking another look into it. (I assume no one is working on it right now)

I've set the priority to NORMAL instead of LOW as indicated.

> I think it'd be good to have two listeners here:
> - The current one at NORMAL priority (which would still be before Citadels HIGH)
> - An additional one at MONITOR priority which removes the block from pendingSnitches if the event was cancelled

If I understand correctly there should be 3 listeners instead of two, am I correct ?

- onBlockPlace(BlockPlaceEvent) at NORMAL
- createReinforcement(ReinforcementCreationEvent) at HIGHEST
- A new listener at MONITOR that removes the entry from pendingSnitches if the event (BlockPlaceEvent?) has been cancelled.