### PR TITLE
Fix snitch range check

### DIFF
--- a/src/main/java/com/untamedears/jukealert/model/field/SingleCuboidRangeManager.java
+++ b/src/main/java/com/untamedears/jukealert/model/field/SingleCuboidRangeManager.java
@@ -22,8 +22,19 @@ public class SingleCuboidRangeManager implements FieldManager {
 
 	@Override
 	public boolean isInside(Location location) {
+		int x = snitch.getLocation().getBlockX();
+		if (location.getBlockX() > (x + range) || location.getBlockX() < (x - range)) {
+			return false;
+		}	
 		int y = snitch.getLocation().getBlockY();
-		return location.getBlockY() <= (y + range) && location.getBlockY() >= (y - range);
+		if (location.getBlockY() > (y + range) || location.getBlockY() < (y - range)) {
+			return false;
+		}	
+		int z = snitch.getLocation().getBlockZ();
+		if (location.getBlockZ() > (z + range) || location.getBlockZ() < (z - range)) {
+			return false;
+		}	
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
symptom: snitches trigger at a range of 12 horizontally, but (correctly) 11 vertically.
This is probably caused by the [quadtree query](https://github.com/CivClassic/JukeAlert/blob/master/src/main/java/com/untamedears/jukealert/SnitchManager.java#L83) lacking precision and could probably be fixed there, but IMHO double-checking here is still a good defensive measure.
I'll be looking at the quadtree next and see if I can find the root cause.

To fix it, I just used the same code as you already had here https://github.com/CivClassic/JukeAlert/commit/6b48fe48b7f0234388cffea902a3171c6a771b33#diff-a5987893a17cb4fd47633d5687630c0eda5316d519e1bffc892c66eb924360a2L26-L38